### PR TITLE
Fix JigsawPlacement error and lag: Correct namespace for 'pillage/str…

### DIFF
--- a/data/create_ltab/worldgen/template_pool/pillage/streets.json
+++ b/data/create_ltab/worldgen/template_pool/pillage/streets.json
@@ -1,0 +1,69 @@
+{
+  "name": "create_ltab:pillage/streets",
+  "elements": [
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "create_ltab:pillage/streets/corner_01",
+        "processors": "minecraft:street_plains",
+        "projection": "terrain_matching"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "create_ltab:pillage/streets/corner_02",
+        "processors": "minecraft:street_plains",
+        "projection": "terrain_matching"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "create_ltab:pillage/streets/crossroad_01",
+        "processors": "minecraft:street_plains",
+        "projection": "terrain_matching"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "create_ltab:pillage/streets/straight_01",
+        "processors": "minecraft:street_plains",
+        "projection": "terrain_matching"
+      },
+      "weight": 4
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "create_ltab:pillage/streets/straight_02",
+        "processors": "minecraft:street_plains",
+        "projection": "terrain_matching"
+      },
+      "weight": 4
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "create_ltab:pillage/streets/straight_03",
+        "processors": "minecraft:street_plains",
+        "projection": "terrain_matching"
+      },
+      "weight": 7
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "create_ltab:pillage/streets/straight_04",
+        "processors": "minecraft:street_plains",
+        "projection": "terrain_matching"
+      },
+      "weight": 7
+    }
+  ],
+  "fallback": "minecraft:empty"
+}


### PR DESCRIPTION
**Version**
Latest release for minecraft neoforge 1.21.1

### **Description**
This PR fixes a critical issue causing severe console spam and TPS drops during world generation, specifically related to the Pillager structures.

**The Issue**
When generating chunks containing Pillager outposts/structures, the server console is flooded with the following error: `[Worker-Main-X/WARN] [minecraft/JigsawPlacement]: Empty or non-existent pool: minecraft:pillage/streets`

This causes significant lag (TPS drops) and slows down pre-generation tools like Chunky, as the game fails to locate the requested template pool.

**The Cause**
The structure definition file references the vanilla namespace (`minecraft:pillage/streets`), but the actual template pool file provided by the mod is located/defined under the `create_ltab` namespace. Due to this namespace mismatch, the Jigsaw generator cannot find the file in the `minecraft` path.

**The Fix**
I updated the reference in the structure JSON file (e.g., `outpost_base.json`) to point to the correct namespace:
- Changed: `"minecraft:pillage/streets"`
- To: `"create_ltab:pillage/streets"`

This successfully resolves the "non-existent pool" error, stops the console spam, and restores normal world generation performance.

*Note:* If you decide to readd this structure, you will have to add the other 3 files that were in this folder (decor.json, houses.json, town_centers.json) that had no errors.